### PR TITLE
Fix broken display on iOS

### DIFF
--- a/components/calendar/CalendarGrid.tsx
+++ b/components/calendar/CalendarGrid.tsx
@@ -40,6 +40,7 @@ export default function CalendarGrid({
         emptyDays.map((day, i) => {
           return (
             <div className="border text-center ring-1 ring-gray-400/25" key={i}>
+              {/*TODO: localise empty day  names?*/}
               <div className="text-xs lg:text-base">{dayNames[i]}</div>
             </div>
           )

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -48,7 +48,10 @@ export function getSessionsToday(
   }
 
   const calendarDate = new Date(
-    `${calendarDay.year}-${calendarDay.month + 1}-${calendarDay.day}`,
+    `${calendarDay.year}-${String(calendarDay.month + 1).padStart(
+      2,
+      '0',
+    )}-${String(calendarDay.day).padStart(2, '0')}`,
   )
 
   const sessionsMap = sessions.map(session => {


### PR DESCRIPTION
The SessionItems were not displaying on the calendar view due to a date parsing issue on iOS.

The date string was being passed to new Date() in the format YYYY-M-D which does not seem to be supported on iOS.

Changed the date string to YYYY-MM-DD format which now works on iOS.