### PR TITLE
Fix infinite scroll bug on iOS

### DIFF
--- a/components/calendar/CalendarMobile.tsx
+++ b/components/calendar/CalendarMobile.tsx
@@ -5,25 +5,40 @@ import {generateCalendarMonth, getSessionsToday} from '@/lib/calendar'
 import DayMobile from '@/components/calendar/DayMobile'
 import useIntersectionObserver from '@/lib/useIntersectionObserver'
 
-const InfiniteScrollCalendar = ({
+export type Day = {
+  day: number
+  weekDay: number
+  month: number
+  year: number
+}
+
+const now = new Date()
+const today = now.getDate()
+const thisMonth = now.getMonth()
+const thisYear = now.getFullYear()
+const startDay = {day: today, weekDay: 0, month: thisMonth, year: thisYear}
+
+export default function CalendarMobile({
   sessions,
 }: {
   sessions?: Session[] | SessionSerialisedDate[]
-}) => {
-  const now = new Date()
-  const [startYear, setStartYear] = useState(() => now.getFullYear())
+}) {
+  const [startYear, setStartYear] = useState(() => thisYear)
+  const [isFrozen, setIsFrozen] = useState(false)
   const [endYear, setEndYear] = useState(startYear)
-  const [startMonth, setStartMonth] = useState(() => now.getMonth())
+  const [startMonth, setStartMonth] = useState(() => thisMonth)
   const [endMonth, setEndMonth] = useState(startMonth)
-  const [data, setData] = useState(() =>
+  const [data, setData] = useState<Day[]>(() =>
     generateCalendarMonth(startMonth, startYear),
   )
-  const startElementRef = useRef(null)
+  const startElementRef = useRef<HTMLDivElement>(null)
   const endElementRef = useRef(null)
+  const scrollToRef = useRef<HTMLDivElement>(null)
   const startEntry = useIntersectionObserver(startElementRef, {})
   const endEntry = useIntersectionObserver(endElementRef, {})
   const isStartVisible = !!startEntry?.isIntersecting
   const isEndVisible = !!endEntry?.isIntersecting
+  const [scrollToThisDay, setScrollThisDay] = useState<Day>(startDay)
 
   const loadNextMonth = useCallback(() => {
     if (endMonth === 11) {
@@ -47,32 +62,70 @@ const InfiniteScrollCalendar = ({
     }
   }, [endMonth, endYear])
 
-  const loadPreviousMonth = useCallback(() => {
+  // FIXME: adding a delay to loadPreviousMonth and blocking it is a hacky way to prevent iOS mobile
+  //  from scrolling up continuously very fast and loading infinite data when scroll to top of screen.
+  //  Seems related: https://github.com/vercel/next.js/issues/28778
+  const delay = (time: number) =>
+    new Promise(resolve => {
+      setTimeout(() => resolve(1), time)
+    })
+
+  const loadPreviousMonth = useCallback(async () => {
     if (startMonth === 0) {
       const newMonth = 11
       const newYear = startYear - 1
+      const prevMonth = generateCalendarMonth(newMonth, newYear)
 
-      setData(prevData => [
-        ...generateCalendarMonth(newMonth, newYear),
-        ...prevData,
-      ])
+      setScrollThisDay(prevMonth[prevMonth.length - 1])
+      setData(prevData => [...prevMonth, ...prevData])
       setStartMonth(newMonth)
       setStartYear(newYear)
     } else {
       const newMonth = startMonth - 1
+      const prevMonth = generateCalendarMonth(newMonth, startYear)
 
-      setData(prevData => [
-        ...generateCalendarMonth(newMonth, startYear),
-        ...prevData,
-      ])
+      setScrollThisDay(prevMonth[prevMonth.length - 1])
+      setData(prevData => [...prevMonth, ...prevData])
       setStartMonth(newMonth)
     }
+
+    await delay(500)
   }, [startMonth, startYear])
 
   useEffect(() => {
+    async function loadPrev() {
+      setIsFrozen(true)
+      await loadPreviousMonth()
+      setIsFrozen(false)
+    }
+
+    if (isStartVisible && !isFrozen) {
+      void loadPrev()
+    }
+  }, [isFrozen, isStartVisible, loadPreviousMonth])
+
+  useEffect(() => {
     if (isEndVisible) loadNextMonth()
-    if (isStartVisible) loadPreviousMonth()
-  }, [isStartVisible, isEndVisible, loadNextMonth, loadPreviousMonth])
+  }, [isEndVisible, loadNextMonth])
+
+  function shouldScrollToThisDay(dayFoo: {
+    day: number
+    weekDay: number
+    month: number
+    year: number
+  }) {
+    const {day, month, year} = dayFoo
+
+    return (
+      scrollToThisDay?.month === month &&
+      scrollToThisDay.year === year &&
+      scrollToThisDay.day === day
+    )
+  }
+
+  useEffect(() => {
+    scrollToRef.current?.scrollIntoView()
+  }, [scrollToThisDay])
 
   return (
     <div className="p-5">
@@ -81,16 +134,15 @@ const InfiniteScrollCalendar = ({
         const sessionsToday = sessions ? getSessionsToday(sessions, day) : null
 
         return (
-          <DayMobile
+          <div
+            ref={shouldScrollToThisDay(day) ? scrollToRef : null}
             key={`${day.day}-${day.month}-${day.year}`}
-            dayData={day}
-            sessionsToday={sessionsToday}
-          />
+          >
+            <DayMobile dayData={day} sessionsToday={sessionsToday} />
+          </div>
         )
       })}
       <div ref={endElementRef}></div>
     </div>
   )
 }
-
-export default InfiniteScrollCalendar

--- a/components/calendar/DayMobile.tsx
+++ b/components/calendar/DayMobile.tsx
@@ -1,55 +1,39 @@
 import Link from 'next/link'
-import React, {useEffect, useRef} from 'react'
 import {Session} from '@prisma/client'
 import {SessionSerialisedDate} from '@/app/(training-app)/training-studio/page'
+import {Day} from '@/components/calendar/CalendarMobile'
 
 const now = new Date()
+const today = now.getDate()
+const thisMonth = now.getMonth()
+const thisYear = now.getFullYear()
 
 export default function DayMobile({
   dayData,
   sessionsToday,
 }: {
-  dayData: {day: number; weekDay: number; month: number; year: number}
+  dayData: Day
   sessionsToday:
     | (Session | SessionSerialisedDate | undefined)[]
     | null
     | undefined
 }) {
-  const dayRef = useRef<HTMLDivElement>(null)
-  const {day, month, year} = dayData
-
-  useEffect(() => {
-    dayRef.current?.scrollIntoView()
-  }, [])
-
-  const weekday = new Date(year, month, day).toLocaleString('default', {
-    weekday: 'long',
-  })
-
-  const monthName = new Date(year, month, day).toLocaleString('default', {
-    month: 'short',
-  })
-
-  const isToday =
-    day === now.getDate() &&
-    month === now.getMonth() &&
-    year === now.getFullYear()
-
-  const isTomorrow =
-    day === now.getDate() + 1 &&
-    month === now.getMonth() &&
-    year === now.getFullYear()
+  const isToday = isDayToday(dayData)
+  const isTomorrow = isDayTomorrow(dayData)
+  const weekday = getWeekday(dayData)
+  const monthName = getMonthName(dayData)
 
   return (
-    <div
-      ref={isToday ? dayRef : null}
-      className={isToday ? 'scroll-mt-16' : ''}
-    >
+    <div className={isToday ? 'scroll-mt-16' : ''}>
       <hr className="my-6 h-px border-none bg-gray-900 dark:bg-gray-700" />
       <div className="mb-2 flex justify-between text-sm text-gray-500">
         <div className="font-bold">{weekday}</div>
         <div>
-          {isToday ? 'Today' : isTomorrow ? 'Tomorrow' : day + ' ' + monthName}
+          {isToday
+            ? 'Today'
+            : isTomorrow
+            ? 'Tomorrow'
+            : dayData.day + ' ' + monthName}
         </div>
       </div>
       {sessionsToday &&
@@ -67,4 +51,32 @@ export default function DayMobile({
         })}
     </div>
   )
+}
+
+export function isDayToday(dayData: Day) {
+  const {day, month, year} = dayData
+
+  return day === today && month === thisMonth && year === thisYear
+}
+
+function isDayTomorrow(dayData: Day) {
+  const {day, month, year} = dayData
+
+  return day === today + 1 && month === thisMonth && year === thisYear
+}
+
+function getWeekday(dayData: Day) {
+  const {day, month, year} = dayData
+
+  return new Date(year, month, day).toLocaleString('default', {
+    weekday: 'long',
+  })
+}
+
+function getMonthName(dayData: Day) {
+  const {day, month, year} = dayData
+
+  return new Date(year, month, day).toLocaleString('default', {
+    month: 'short',
+  })
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -21,5 +21,4 @@
 html,
 body {
   max-width: 100vw;
-  overflow-x: hidden;
 }


### PR DESCRIPTION
When scrolling up, it scrolls really fast and too far without stopping.
Hacky solution is, when scrolling up and loading the previous month, add a ref to the last day of the new previous month, then `ref.scrollIntoView()` when the ref changes. So instead of continuously scrolling, it scrolls back to the end of the month, which is where you'd expect to be when scrolling up from eg March to February. Also added a 500ms delay after loading the new month and setting the new scrollToRef, to prevent continuously loading and setting new refs.
It was also necessary to remove the css `html, body {overflow-x: hidden;}` which I got from https://github.com/vercel/next.js/issues/28778
Coding is hard.