### PR TITLE
Make calendar refresh when mutated

### DIFF
--- a/app/(training-app)/training-planner/page.tsx
+++ b/app/(training-app)/training-planner/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import {User} from '@/components/calendar/CalendarDropdown'
-import {useEffect, useState} from 'react'
+import {useCallback, useEffect, useState} from 'react'
 import {fetchSessions} from '@/lib/api'
 import Calendar from '@/components/calendar/Calendar'
 import Sidebar from '@/components/calendar/Sidebar'
@@ -12,21 +12,26 @@ export default function TrainingPlanner() {
   const [sessions, setSessions] = useState<Session[]>()
   const [sessionId, setSessionId] = useState('')
 
-  useEffect(() => {
-    const getUserSessions = async () => {
-      if (user) {
-        const sessions = await fetchSessions(user.id)
+  const getUserSessions = useCallback(async () => {
+    if (user) {
+      const sessions = await fetchSessions(user.id)
 
-        setSessions(sessions)
-      }
+      setSessions(sessions)
     }
-
-    void getUserSessions()
   }, [user])
+
+  useEffect(() => {
+    void getUserSessions()
+  }, [getUserSessions, user])
 
   return (
     <div className="flex h-[90vh]">
-      <Sidebar setUser={setUser} user={user} sessionId={sessionId} />
+      <Sidebar
+        setUser={setUser}
+        user={user}
+        sessionId={sessionId}
+        getUserSessions={getUserSessions}
+      />
       <Calendar sessions={sessions} isAdmin setSessionId={setSessionId} />
     </div>
   )

--- a/components/calendar/CalendarForm.tsx
+++ b/components/calendar/CalendarForm.tsx
@@ -13,9 +13,11 @@ import {useRouter} from 'next/navigation'
 export default function CalendarForm({
   sessionId,
   userId = '',
+  getUserSessions,
 }: {
   sessionId?: string
   userId?: string
+  getUserSessions: () => Promise<void>
 }) {
   const initialState: {
     error: null | Error
@@ -98,11 +100,11 @@ export default function CalendarForm({
         status: 'resolved',
       })
 
-      // FIXME: make page fetch updated sessions in calendar
       // router.refresh() should refresh (fetch updated data and re-render on the server)
-      // the current route from the root layout down?
+      // the current route from the root layout down?  Doesn't seem to work currently.
       // https://beta.nextjs.org/docs/data-fetching/mutating
-      router.refresh()
+      // Temporary workaround:
+      void getUserSessions()
     } catch (error) {
       setState({
         ...state,
@@ -128,11 +130,11 @@ export default function CalendarForm({
         status: 'resolved',
       })
 
-      // FIXME: make page fetch updated sessions in calendar
       // router.refresh() should refresh (fetch updated data and re-render on the server)
-      // the current route from the root layout down?
+      // the current route from the root layout down?  Doesn't seem to work currently.
       // https://beta.nextjs.org/docs/data-fetching/mutating
-      router.refresh()
+      // Temporary workaround:
+      void getUserSessions()
     } catch (error) {
       setState({
         ...state,

--- a/components/calendar/Sidebar.tsx
+++ b/components/calendar/Sidebar.tsx
@@ -6,10 +6,12 @@ export default function Sidebar({
   setUser,
   user,
   sessionId,
+  getUserSessions,
 }: {
   setUser: React.Dispatch<React.SetStateAction<User | undefined>>
   user?: User
   sessionId: string
+  getUserSessions: () => Promise<void>
 }) {
   return (
     <aside className="flex w-72 flex-col overflow-y-auto border-r bg-white px-4 py-8 rtl:border-r-0 rtl:border-l dark:border-gray-700 dark:bg-gray-900">
@@ -17,7 +19,11 @@ export default function Sidebar({
         {user && `${user.firstName} ${user.lastName}`}
       </span>
       <CalendarDropdown setUser={setUser} />
-      <CalendarForm userId={user?.id} sessionId={sessionId} />
+      <CalendarForm
+        userId={user?.id}
+        sessionId={sessionId}
+        getUserSessions={getUserSessions}
+      />
     </aside>
   )
 }


### PR DESCRIPTION
According to the docs, router.refresh() should do this, but it doesn't seem to.  So added a temporary workaround.