### PR TITLE
Refactor calendar components

### DIFF
--- a/app/(training-app)/layout.tsx
+++ b/app/(training-app)/layout.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import CalendarNavbar from '@/components/calendar/CalendarNavbar'
+import {CalendarNavbar} from '@/components/calendar/CalendarNavbar'
 import {getUserFromCookie} from '@/lib/auth'
 import {cookies} from 'next/headers'
 import {redirect} from 'next/navigation'

--- a/app/(training-app)/training-planner/page.tsx
+++ b/app/(training-app)/training-planner/page.tsx
@@ -1,16 +1,34 @@
 'use client'
 
-import {User} from '@/components/calendar/CalendarDropdown'
-import {useCallback, useEffect, useState} from 'react'
+import React, {useCallback, useEffect, useState} from 'react'
 import {fetchSessions} from '@/lib/api'
-import Calendar from '@/components/calendar/Calendar'
-import Sidebar from '@/components/calendar/Sidebar'
 import {Session} from '@prisma/client'
+import {useCalendarData, useMediaQuery} from '@/hooks'
+import {CalendarMobile} from '@/components/calendar/CalendarMobile'
+import {CalendarDropdown, User} from '@/components/calendar/CalendarDropdown'
+import {CalendarForm} from '@/components/calendar/CalendarForm'
+import {Calendar} from '@/components/calendar/Calendar'
+import {CalendarDays} from '@/components/calendar/CalendarDays'
+import {CalendarEmptyDays} from '@/components/calendar/CalendarEmptyDays'
+import {CalendarGrid} from '@/components/calendar/CalendarGrid'
+import {CalendarHeading} from '@/components/calendar/CalendarHeading'
+import {Sidebar} from '@/components/calendar/Sidebar'
+import {UserName} from '@/components/calendar/UserName'
 
 export default function TrainingPlanner() {
   const [user, setUser] = useState<User>()
   const [sessions, setSessions] = useState<Session[]>()
   const [sessionId, setSessionId] = useState('')
+  const {
+    calendarSquares,
+    emptyDays,
+    monthData,
+    year,
+    month,
+    setYear,
+    setMonth,
+  } = useCalendarData()
+  const isMobile = useMediaQuery('(max-width: 639px)')
 
   const getUserSessions = useCallback(async () => {
     if (user) {
@@ -24,15 +42,46 @@ export default function TrainingPlanner() {
     void getUserSessions()
   }, [getUserSessions, user])
 
+  useEffect(() => {
+    // Lock scroll for large screens
+    if (!isMobile) document.body.style.overflow = 'hidden'
+    if (isMobile) document.body.style.overflow = 'visible'
+  }, [isMobile])
+
   return (
     <div className="flex h-[90vh]">
-      <Sidebar
-        setUser={setUser}
-        user={user}
-        sessionId={sessionId}
-        getUserSessions={getUserSessions}
-      />
-      <Calendar sessions={sessions} isAdmin setSessionId={setSessionId} />
+      <Sidebar>
+        <UserName user={user} />
+        <CalendarDropdown setUser={setUser} />
+        <CalendarForm
+          userId={user?.id}
+          sessionId={sessionId}
+          getUserSessions={getUserSessions}
+        />
+      </Sidebar>
+      <Calendar>
+        {isMobile && <CalendarMobile sessions={sessions} />}
+
+        {!isMobile && (
+          <>
+            <CalendarHeading
+              year={year}
+              setYear={setYear}
+              month={month}
+              setMonth={setMonth}
+            />
+            <CalendarGrid calendarSquares={calendarSquares}>
+              <CalendarEmptyDays emptyDays={emptyDays} />
+              <CalendarDays
+                monthData={monthData}
+                sessions={sessions}
+                isAdmin
+                setSessionId={setSessionId}
+              />
+            </CalendarGrid>
+          </>
+        )}
+      </Calendar>
     </div>
   )
 }

--- a/app/(training-app)/training-studio/page.tsx
+++ b/app/(training-app)/training-studio/page.tsx
@@ -1,8 +1,9 @@
 import {getUserFromCookie} from '@/lib/auth'
 import {cookies} from 'next/headers'
 import {db} from '@/lib/db'
-import Calendar from '@/components/calendar/Calendar'
 import {Session, SESSION_STATUS, SESSION_TYPE} from '@prisma/client'
+import React from 'react'
+import {AppContainer} from '@/components/calendar/AppContainer'
 
 export interface SessionSerialisedDate {
   id: string
@@ -16,7 +17,7 @@ export interface SessionSerialisedDate {
   sessionType: SESSION_TYPE
 }
 
-const getSessions = async () => {
+const getSessions = async (): Promise<SessionSerialisedDate[]> => {
   const user = await getUserFromCookie(cookies())
 
   const sessions = await db.session.findMany({
@@ -28,9 +29,7 @@ const getSessions = async () => {
     },
   })
 
-  const serialisedSessions = serialiseDates(sessions)
-
-  return {serialisedSessions}
+  return serialiseDates(sessions)
 }
 
 function serialiseDates(sessions: Session[]) {
@@ -43,11 +42,8 @@ function serialiseDates(sessions: Session[]) {
 }
 
 export default async function TrainingStudio() {
-  const {serialisedSessions} = await getSessions()
+  const serialisedSessions = await getSessions()
 
-  return (
-    <div className="flex h-[90vh]">
-      <Calendar sessions={serialisedSessions} />
-    </div>
-  )
+  // Fetch the sessions in this server component to pass to 'use client' component
+  return <AppContainer sessions={serialisedSessions} />
 }

--- a/components/calendar/AppContainer.tsx
+++ b/components/calendar/AppContainer.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import React, {useEffect} from 'react'
+import {useCalendarData, useMediaQuery} from '@/hooks'
+import {Calendar} from '@/components/calendar/Calendar'
+import {CalendarDays} from '@/components/calendar/CalendarDays'
+import {CalendarEmptyDays} from '@/components/calendar/CalendarEmptyDays'
+import {CalendarGrid} from '@/components/calendar/CalendarGrid'
+import {CalendarHeading} from '@/components/calendar/CalendarHeading'
+import {CalendarMobile} from '@/components/calendar/CalendarMobile'
+import {SessionSerialisedDate} from '@/app/(training-app)/training-studio/page'
+
+export function AppContainer({sessions}: {sessions: SessionSerialisedDate[]}) {
+  const {
+    calendarSquares,
+    emptyDays,
+    monthData,
+    year,
+    month,
+    setYear,
+    setMonth,
+  } = useCalendarData()
+  const isMobile = useMediaQuery('(max-width: 639px)')
+
+  useEffect(() => {
+    // Lock scroll for large screens
+    if (!isMobile) document.body.style.overflow = 'hidden'
+    if (isMobile) document.body.style.overflow = 'visible'
+  }, [isMobile])
+
+  return (
+    <div className="flex h-[90vh]">
+      <Calendar>
+        {isMobile && <CalendarMobile sessions={sessions} />}
+
+        {!isMobile && (
+          <>
+            <CalendarHeading
+              year={year}
+              setYear={setYear}
+              month={month}
+              setMonth={setMonth}
+            />
+            <CalendarGrid calendarSquares={calendarSquares}>
+              <CalendarEmptyDays emptyDays={emptyDays} />
+              <CalendarDays monthData={monthData} sessions={sessions} />
+            </CalendarGrid>
+          </>
+        )}
+      </Calendar>
+    </div>
+  )
+}

--- a/components/calendar/Calendar.tsx
+++ b/components/calendar/Calendar.tsx
@@ -1,54 +1,7 @@
-'use client'
+import React from 'react'
 
-import {Session} from '@prisma/client'
-import React, {useEffect, useState} from 'react'
-import CalendarHeading from '@/components/calendar/CalendarHeading'
-import CalendarGrid from '@/components/calendar/CalendarGrid'
-import {SessionSerialisedDate} from '@/app/(training-app)/training-studio/page'
-import {useMediaQuery} from '@/hooks'
-import CalendarMobile from '@/components/calendar/CalendarMobile'
-
-const now = new Date()
-
-export default function Calendar({
-  isAdmin = false,
-  sessions,
-  setSessionId,
-}: {
-  isAdmin?: boolean
-  sessions?: Session[] | SessionSerialisedDate[]
-  setSessionId?: React.Dispatch<React.SetStateAction<string>>
-}) {
-  const [year, setYear] = useState(() => now.getFullYear())
-  const [month, setMonth] = useState(() => now.getMonth())
-  const isMobile = useMediaQuery('(max-width: 639px)')
-
-  useEffect(() => {
-    if (!isMobile) document.body.style.overflow = 'hidden'
-    if (isMobile) document.body.style.overflow = 'visible'
-  }, [isMobile])
-
+export function Calendar({children}: {children: React.ReactNode}) {
   return (
-    <div className="flex w-full flex-col px-5 sm:items-center ">
-      {isMobile && <CalendarMobile sessions={sessions} />}
-
-      {!isMobile && (
-        <>
-          <CalendarHeading
-            year={year}
-            setYear={setYear}
-            month={month}
-            setMonth={setMonth}
-          />
-          <CalendarGrid
-            year={year}
-            month={month}
-            sessions={sessions}
-            isAdmin={isAdmin}
-            setSessionId={setSessionId}
-          />
-        </>
-      )}
-    </div>
+    <div className="flex w-full flex-col px-5 sm:items-center ">{children}</div>
   )
 }

--- a/components/calendar/CalendarDay.tsx
+++ b/components/calendar/CalendarDay.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import {Day, getShortWeekday, isDayToday} from '@/lib/calendar'
+
+export function CalendarDay({
+  day,
+  isFirstWeek,
+  children,
+}: {
+  day: Day
+  isFirstWeek: boolean
+  children: React.ReactNode
+}) {
+  const weekday = getShortWeekday(day)
+  const isToday = isDayToday(day)
+
+  return (
+    <div
+      className="border text-center ring-1 ring-gray-400/25"
+      key={day.day + day.year + day.month}
+    >
+      {isFirstWeek && <div className="text-xs lg:text-base">{weekday}</div>}
+      <div
+        className={
+          'mx-auto w-6 rounded-full p-1 text-xs lg:w-8 lg:text-base' +
+          (isToday ? ` bg-blue-900 text-white` : '')
+        }
+      >
+        {day.day}
+      </div>
+      {children}
+    </div>
+  )
+}

--- a/components/calendar/CalendarDays.tsx
+++ b/components/calendar/CalendarDays.tsx
@@ -1,0 +1,40 @@
+import {Day, getSessionsToday} from '@/lib/calendar'
+import React from 'react'
+import {Session} from '@prisma/client'
+import {SessionSerialisedDate} from '@/app/(training-app)/training-studio/page'
+import {CalendarDay} from '@/components/calendar/CalendarDay'
+import {SessionItems} from '@/components/calendar/SessionItems'
+
+export function CalendarDays({
+  monthData,
+  sessions,
+  setSessionId,
+  isAdmin = false,
+}: {
+  monthData: Day[]
+  sessions?: Session[] | SessionSerialisedDate[]
+  setSessionId?: React.Dispatch<React.SetStateAction<string>>
+  isAdmin?: boolean
+}) {
+  const firstDayOfMonth = monthData[0].weekDay
+
+  return (
+    <>
+      {monthData.map((day, index) => {
+        const sessionsToday = sessions ? getSessionsToday(sessions, day) : null
+        const isFirstWeek = index + firstDayOfMonth < 7
+
+        return (
+          <CalendarDay day={day} isFirstWeek={isFirstWeek} key={index}>
+            <SessionItems
+              sessions={sessionsToday}
+              setSessionId={setSessionId}
+              isAdmin={isAdmin}
+              day={day}
+            />
+          </CalendarDay>
+        )
+      })}
+    </>
+  )
+}

--- a/components/calendar/CalendarDropdown.tsx
+++ b/components/calendar/CalendarDropdown.tsx
@@ -10,7 +10,7 @@ export interface User {
   id: string
 }
 
-export default function CalendarDropdown({
+export function CalendarDropdown({
   setUser,
 }: {
   setUser: React.Dispatch<React.SetStateAction<User | undefined>>

--- a/components/calendar/CalendarEmptyDays.tsx
+++ b/components/calendar/CalendarEmptyDays.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+export function CalendarEmptyDays({emptyDays}: {emptyDays: null[]}) {
+  if (!emptyDays.length) {
+    return null
+  }
+
+  return (
+    <>
+      {emptyDays.map((_day, i) => {
+        return (
+          <div className="border text-center ring-1 ring-gray-400/25" key={i}>
+            {/*TODO: localise empty day names?*/}
+            <div className="text-xs lg:text-base">{dayNames[i]}</div>
+          </div>
+        )
+      })}
+    </>
+  )
+}

--- a/components/calendar/CalendarForm.tsx
+++ b/components/calendar/CalendarForm.tsx
@@ -4,7 +4,7 @@ import Info from '@/components/Info'
 import {SESSION_TYPE} from '@prisma/client'
 import {useCalendarForm, useStatus} from '@/hooks'
 
-export default function CalendarForm({
+export function CalendarForm({
   sessionId,
   userId = '',
   getUserSessions,

--- a/components/calendar/CalendarGrid.tsx
+++ b/components/calendar/CalendarGrid.tsx
@@ -1,38 +1,13 @@
-import React, {useMemo} from 'react'
-import {
-  generateCalendarMonth,
-  getSessionsToday,
-  getShortWeekday,
-  isDayToday,
-} from '@/lib/calendar'
-import SessionItem from '@/components/calendar/SessionItem'
-import {Session} from '@prisma/client'
-import {SessionSerialisedDate} from '@/app/(training-app)/training-studio/page'
+import React from 'react'
 import {classNames} from '@/lib/misc'
 
-const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
-
-export default function CalendarGrid({
-  year,
-  month,
-  sessions,
-  isAdmin,
-  setSessionId,
+export function CalendarGrid({
+  calendarSquares,
+  children,
 }: {
-  year: number
-  month: number
-  sessions?: Session[] | SessionSerialisedDate[]
-  isAdmin: boolean
-  setSessionId?: React.Dispatch<React.SetStateAction<string>>
+  calendarSquares: number
+  children: React.ReactNode
 }) {
-  const monthData = useMemo(
-    () => generateCalendarMonth(month, year),
-    [month, year],
-  )
-  const firstDayOfMonth = monthData[0].weekDay
-  const emptyDays = Array(firstDayOfMonth).fill(null)
-  const calendarSquares = firstDayOfMonth + monthData.length
-
   return (
     <div
       className={classNames(
@@ -40,54 +15,7 @@ export default function CalendarGrid({
         'grid h-full w-full grid-cols-calendar ring-offset-1',
       )}
     >
-      {emptyDays &&
-        emptyDays.map((_day, i) => {
-          return (
-            <div className="border text-center ring-1 ring-gray-400/25" key={i}>
-              {/*TODO: localise empty day names?*/}
-              <div className="text-xs lg:text-base">{dayNames[i]}</div>
-            </div>
-          )
-        })}
-
-      {monthData.map((day, index) => {
-        const weekday = getShortWeekday(day)
-        const sessionsToday = sessions ? getSessionsToday(sessions, day) : null
-        const isToday = isDayToday(day)
-
-        return (
-          <div
-            className="border text-center ring-1 ring-gray-400/25"
-            key={day.day + day.year + day.month}
-          >
-            {index + firstDayOfMonth < 7 && (
-              <div className="text-xs lg:text-base">{weekday}</div>
-            )}
-            <div
-              className={
-                'mx-auto w-6 rounded-full p-1 text-xs lg:w-8 lg:text-base' +
-                (isToday ? ` bg-blue-900 text-white` : '')
-              }
-            >
-              {day.day}
-            </div>
-            {sessionsToday &&
-              sessionsToday.map((session, i) => {
-                return (
-                  <div key={day.day * day.year * day.month * i}>
-                    {session && (
-                      <SessionItem
-                        session={session}
-                        isAdmin={isAdmin}
-                        setSessionId={setSessionId}
-                      />
-                    )}
-                  </div>
-                )
-              })}
-          </div>
-        )
-      })}
+      {children}
     </div>
   )
 }

--- a/components/calendar/CalendarHeading.tsx
+++ b/components/calendar/CalendarHeading.tsx
@@ -15,7 +15,7 @@ const monthNames = [
   'December',
 ]
 
-export default function CalendarHeading({
+export function CalendarHeading({
   year,
   month,
   setYear,

--- a/components/calendar/CalendarMobile.tsx
+++ b/components/calendar/CalendarMobile.tsx
@@ -1,18 +1,20 @@
+'use client'
+
 import React, {useEffect, useRef, useState} from 'react'
 import {Session} from '@prisma/client'
 import {SessionSerialisedDate} from '@/app/(training-app)/training-studio/page'
 import {getSessionsToday, shouldScrollToThisDay} from '@/lib/calendar'
-import DayMobile from '@/components/calendar/DayMobile'
-import {useCalendarData, useCalendarIntersectionObserver} from '@/hooks'
+import {DayMobile} from '@/components/calendar/DayMobile'
+import {useMobileCalendarData, useCalendarIntersectionObserver} from '@/hooks'
 
-export default function CalendarMobile({
+export function CalendarMobile({
   sessions,
 }: {
   sessions?: Session[] | SessionSerialisedDate[]
 }) {
   const [isFrozen, setIsFrozen] = useState(false)
   const {data, scrollToThisDay, loadNextMonth, loadPreviousMonth} =
-    useCalendarData()
+    useMobileCalendarData()
   const startElementRef = useRef<HTMLDivElement>(null)
   const endElementRef = useRef(null)
   const scrollToRef = useRef<HTMLDivElement>(null)

--- a/components/calendar/CalendarNavbar.tsx
+++ b/components/calendar/CalendarNavbar.tsx
@@ -1,7 +1,7 @@
-import CalendarNavbarClient from '@/components/calendar/CalendarNavbarClient'
+import {CalendarNavbarClient} from '@/components/calendar/CalendarNavbarClient'
 import {getByContentTypeId} from '@/lib/contentful'
 
-export default async function CalendarNavbar({isAdmin}: {isAdmin: boolean}) {
+export async function CalendarNavbar({isAdmin}: {isAdmin: boolean}) {
   const {items} = await getByContentTypeId('navbar', {
     include: 3,
   })

--- a/components/calendar/CalendarNavbarClient.tsx
+++ b/components/calendar/CalendarNavbarClient.tsx
@@ -29,7 +29,7 @@ const clientNavigation = [
   {href: '/profile', name: 'Profile'},
 ]
 
-export default function CalendarNavbarClient({logo, isAdmin}: Props) {
+export function CalendarNavbarClient({logo, isAdmin}: Props) {
   const {src, alt, width, height} = logo
   const router = useRouter()
   const navigation = isAdmin ? adminNavigation : clientNavigation

--- a/components/calendar/DayMobile.tsx
+++ b/components/calendar/DayMobile.tsx
@@ -7,9 +7,9 @@ import {
   isDayToday,
   isDayTomorrow,
 } from '@/lib/calendar'
-import SessionItemMobile from '@/components/calendar/SessionItemMobile'
+import {SessionItemMobile} from '@/components/calendar/SessionItemMobile'
 
-export default function DayMobile({
+export function DayMobile({
   dayData,
   sessionsToday,
 }: {

--- a/components/calendar/SessionItem.tsx
+++ b/components/calendar/SessionItem.tsx
@@ -6,7 +6,7 @@ import {SESSION_STATUS} from '.prisma/client'
 import {useSessionStatus} from '@/hooks'
 import {classNames} from '@/lib/misc'
 
-export default function SessionItem({
+export function SessionItem({
   session,
   isAdmin,
   setSessionId,

--- a/components/calendar/SessionItemMobile.tsx
+++ b/components/calendar/SessionItemMobile.tsx
@@ -5,7 +5,7 @@ import {SESSION_STATUS} from '.prisma/client'
 import {classNames} from '@/lib/misc'
 import {useSessionStatus} from '@/hooks'
 
-export default function SessionItemMobile({
+export function SessionItemMobile({
   session,
 }: {
   session: Session | SessionSerialisedDate

--- a/components/calendar/SessionItems.tsx
+++ b/components/calendar/SessionItems.tsx
@@ -1,0 +1,39 @@
+import {Session} from '@prisma/client'
+import {SessionSerialisedDate} from '@/app/(training-app)/training-studio/page'
+import {SessionItem} from '@/components/calendar/SessionItem'
+import React from 'react'
+import {Day} from '@/lib/calendar'
+
+export function SessionItems({
+  sessions,
+  setSessionId,
+  isAdmin,
+  day,
+}: {
+  sessions: (Session | SessionSerialisedDate | undefined)[] | null | undefined
+  setSessionId?: React.Dispatch<React.SetStateAction<string>>
+  isAdmin: boolean
+  day: Day
+}) {
+  if (!sessions) {
+    return null
+  }
+
+  return (
+    <>
+      {sessions.map((session, i) => {
+        return (
+          <div key={day.day * day.year * day.month * i}>
+            {session && (
+              <SessionItem
+                session={session}
+                isAdmin={isAdmin}
+                setSessionId={setSessionId}
+              />
+            )}
+          </div>
+        )
+      })}
+    </>
+  )
+}

--- a/components/calendar/Sidebar.tsx
+++ b/components/calendar/Sidebar.tsx
@@ -1,29 +1,9 @@
-import CalendarForm from '@/components/calendar/CalendarForm'
-import CalendarDropdown, {User} from '@/components/calendar/CalendarDropdown'
 import React from 'react'
 
-export default function Sidebar({
-  setUser,
-  user,
-  sessionId,
-  getUserSessions,
-}: {
-  setUser: React.Dispatch<React.SetStateAction<User | undefined>>
-  user?: User
-  sessionId: string
-  getUserSessions: () => Promise<void>
-}) {
+export function Sidebar({children}: {children: React.ReactNode}) {
   return (
     <aside className="flex w-72 flex-col overflow-y-auto border-r bg-white px-4 py-8 rtl:border-r-0 rtl:border-l dark:border-gray-700 dark:bg-gray-900">
-      <span className="mt-4 text-center font-medium text-gray-800 dark:text-gray-200">
-        {user && `${user.firstName} ${user.lastName}`}
-      </span>
-      <CalendarDropdown setUser={setUser} />
-      <CalendarForm
-        userId={user?.id}
-        sessionId={sessionId}
-        getUserSessions={getUserSessions}
-      />
+      {children}
     </aside>
   )
 }

--- a/components/calendar/UserName.tsx
+++ b/components/calendar/UserName.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import {User} from '@/components/calendar/CalendarDropdown'
+
+export function UserName({user}: {user?: User}) {
+  if (!user) {
+    return null
+  }
+
+  return (
+    <span className="mt-4 text-center font-medium text-gray-800 dark:text-gray-200">
+      {user && `${user.firstName} ${user.lastName}`}
+    </span>
+  )
+}

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -1,6 +1,9 @@
+'use client'
+
+export * from './useCalendarData'
 export * from './useCalendarForm'
 export * from './useFetchSession'
-export * from './useCalendarData'
+export * from './useMobileCalendarData'
 export * from './useStatus'
 export * from './useSessionStatus'
 export * from './useCalendarIntersectionObserver'

--- a/hooks/useCalendarData.tsx
+++ b/hooks/useCalendarData.tsx
@@ -1,0 +1,18 @@
+import {useMemo, useState} from 'react'
+import {generateCalendarMonth} from '@/lib/calendar'
+
+const now = new Date()
+
+export function useCalendarData() {
+  const [year, setYear] = useState(() => now.getFullYear())
+  const [month, setMonth] = useState(() => now.getMonth())
+  const monthData = useMemo(
+    () => generateCalendarMonth(month, year),
+    [month, year],
+  )
+  const firstDayOfMonth = monthData[0].weekDay
+  const emptyDays = Array(firstDayOfMonth).fill(null)
+  const calendarSquares = firstDayOfMonth + monthData.length
+
+  return {calendarSquares, emptyDays, monthData, year, setYear, month, setMonth}
+}

--- a/hooks/useMobileCalendarData.ts
+++ b/hooks/useMobileCalendarData.ts
@@ -6,7 +6,7 @@ const today = now.getDate()
 const thisMonth = now.getMonth()
 const thisYear = now.getFullYear()
 
-export function useCalendarData() {
+export function useMobileCalendarData() {
   const startDay = {
     day: today,
     weekDay: 0,


### PR DESCRIPTION
Composed the components to reduce prop drilling.

Tried to export calender components from an index.ts, but this broke the app with errors like:
- Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got...
- AccessToken expected in contentful.createClient()

Try again in another PR.